### PR TITLE
Meeting minutes  2025-01-02

### DIFF
--- a/meetings/2025-01-02.md
+++ b/meetings/2025-01-02.md
@@ -95,7 +95,7 @@ https://lf-riscv.atlassian.net/browse/RVS-1915
 
 - no progress to report 
 - Markky "makes a solemn" promises to start the work on the spec
-- looking at litterature on PQC implementation (including a monolithic accelerator with low interest for ISA development with some side-channel protection claims although secret keys are in plaintext)
+- looking at literature on PQC implementation (including a monolithic accelerator with low interest for ISA development with some side-channel protection claims although secret keys are in plaintext)
 - Open Titan looking at OTBN (256-bit variant of RISC-V) https://opentitan.org/book/hw/ip/otbn/
 
 # New Business

--- a/meetings/2025-01-02.md
+++ b/meetings/2025-01-02.md
@@ -1,0 +1,110 @@
+
+Minutes of RISC-V crypto task group(s) meeting of January 2nd 2025
+
+# Presents
+Andrew Dellow (Qualcomm),
+Barry (individual),
+Cay Blomqvist (individual),
+Luis Fiolhais (Individual),
+Markku-Juhani Saarinen (Tampere),
+Nicolas Brunie (SiFive),
+G. Richard Newell (Microchip Technology),
+Tolga Yalcin (Qualcomm)
+
+
+
+Meeting minutes are captured (but not saved) on RISC-V recommended etherpad: https://tech.riscv.org/etherpad/p/crypto
+
+# Useful links
+
+- Group meeting minutes: https://github.com/riscv-admin/post-quantum-cryptography/tree/main/meetings
+- crypto extension mailing list: https://lists.riscv.org/g/tech-crypto-ext
+
+# Misc
+
+last week minutes https://github.com/riscv-admin/post-quantum-cryptography/pull/28/files
+
+
+Running the disclosure at 7:03PM (CET)
+
+# Agenda
+
+Shared by Richard (by email) on January 1st 
+
+ Call to Order
+ Quorum Call
+o Roll call of voting members (Nicolas)
+ Review/Approve Agenda
+ Approve previous meeting minutes (from Dec. 12, 2024)
+ Announcements
+o Industry news and similar announcements
+ CRA WG
+ Report of the CETG
+o Status of the fast-track ISEs (Nicolas)
+ Report of the HACTG
+o Status of the HAC ISE (Richard &amp; Qualcom, if ready)
+o Status of the reference design (Barry)
+ Report of the PQCTG
+o Status of the PQ ISE (Markku)
+ New Business
+ Next meeting (Agenda items, date)
+ Adjournment
+
+Andrew and Cay have not been attending any of the past 3 meetings 
+All other attendees have been.
+
+Agenda approved at 7:07pm
+
+Last meeting minutes https://github.com/riscv-admin/post-quantum-cryptography/pull/28/files
+Approved at 7:09PM
+
+# industry announcement
+
+- Cyber Resiliency Act (follow-up to last meeting discussion)
+      - Markku has joined CENELEC a european working group associated with the CRA: 47X (as Finland national representative)
+     - Of interest for RISC-V (although no direct impact to the ISA)
+    - https://standards.cencenelec.eu/dyn/www/f?p=305:29:0::::FSP_ORG_ID,FSP_LANG_ID:3289823,25&cs=1CA866A799781063889C55649448B0B94#1
+    - CRA requirements will fall down to the microprocessor (and so CRA has microprocessor focused working groups)
+    - They also have FPGA specific working groups
+    - EUCC
+
+- NIST officially asking for comment on wider AES (256-bit block size) https://csrc.nist.gov/News/2024/nist-proposes-to-standardize-wider-variant-of-aes (Rijndael)
+    - Markku suggested to send a comment for RISC-V: suggesting that both scalar and vector crypto extensions should be able to support this wider variant [this would only apply to single round versions, HAC would need new instructions for all-round]
+    - per-Block it adds a byte shuffle
+    - key schedule is completely unmodified (which might actually be a cryptography issue)
+
+# fast track extensions
+
+https://lf-riscv.atlassian.net/browse/RVS-1915
+
+- ARC review is done, spec has been approved (to get to the next spec)
+- Working on spec, opcodes, and isa-sim implementations, next: compiler support, proof of concept
+- May need a discussion on the SAIL implementation as it would need the vector crypto spec which was never merged into spec
+- TODO: add a vote to the meeting agenda once Freeze milestones is within reach
+
+# High Assurance Cryptography 
+
+- Qualcomm is eager to present their proposal but is not ready yet
+- Side meetings have shown that Richard's proposal and Qualcomm proposal are very close
+
+- Barry has encountered some technical issues with the dev environment of the PoC and his looking at solution to restore working environment 
+
+
+# Post-Quantum Cryptography
+
+
+- no progress to report 
+- Markky "makes a solemn" promises to start the work on the spec
+- looking at litterature on PQC implementation (including a monolithic accelerator with low interest for ISA development with some side-channel protection claims although secret keys are in plaintext)
+- Open Titan looking at OTBN (256-bit variant of RISC-V) https://opentitan.org/book/hw/ip/otbn/
+
+# New Business
+
+Andrew: need distinction between official meetings (with voting) and ordinary meetings (like today, discussion only)
+The TGs will need to flag voting meetings specifically so people can make an extra effort to attend and keep their voting rights.
+The difference should be clear in the group atlassian (Jira) space with different populated templates
+
+
+Call for next week agenda items
+
+Meeting is adjourned at 7:40PM (CET)


### PR DESCRIPTION
Minutes for RVIA crypto task groups (PQC + HAC) for January 2nd 2025.